### PR TITLE
Snackbar on deleting storage, delete storage functionality, Undo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@tauri-apps/api": "^2.0.3",
         "next": "14.2.15",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-toastify": "^10.0.6"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.4",
@@ -5143,6 +5144,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "@tauri-apps/api": "^2.0.3",
     "next": "14.2.15",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-toastify": "^10.0.6"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.0.4",

--- a/src/app/flash/firmware/page.tsx
+++ b/src/app/flash/firmware/page.tsx
@@ -3,7 +3,7 @@
 import { Box, Button, Container } from "@mui/material";
 import * as React from "react";
 import Typography from "@mui/material/Typography";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import FirmwareTable from "@/components/FirmwareTable";
 import { FirmwareTableRow } from "@/components/FirmwareTable";
 import HorizontalLinearStepper from "@/components/Stepper";
@@ -13,6 +13,16 @@ import ArrowLeftIcon from "@mui/icons-material/ArrowLeft";
 
 import { invoke } from "@tauri-apps/api/core";
 
+interface StorageCredentials {
+  user_storage_name: string;
+  storage_type: string;
+  storage_name: string;
+  storage_account_id: string;
+  storage_access_key: string;
+  storage_secret_key: string;
+  timestamp: number;
+}
+
 export default function Home() {
   const [activeStep, setActiveStep] = React.useState(1);
   const [rows, setRows] = useState<FirmwareTableRow[]>([
@@ -20,6 +30,17 @@ export default function Home() {
     { id: 1, name: "fizzbuzz", date: "10.2.2021" },
     { id: 2, name: "control", date: "1.1.2020" },
   ]);
+  
+  useEffect(() => {
+    const storageName = sessionStorage.getItem("storageToDelete");
+    if (storageName) {
+      console.log("Performing action for saved storage:", storageName);
+      invoke<StorageCredentials[]>("remove_storage_credentials", {
+        user_storage_name: storageName,
+      });
+      sessionStorage.removeItem("storageToDelete"); // Clean up
+    }
+  }, []);
 
   const [isEditDisabled, setIsEditDisabled] = useState(true);
 

--- a/src/app/flash/firmware/page.tsx
+++ b/src/app/flash/firmware/page.tsx
@@ -24,11 +24,21 @@ interface StorageCredentials {
 }
 
 export default function Home() {
+ 
+
   const [activeStep, setActiveStep] = React.useState(1);
   const [rows, setRows] = useState<FirmwareTableRow[]>([
     { id: 0, name: "blink", date: "18.3.2021" },
     { id: 1, name: "fizzbuzz", date: "10.2.2021" },
     { id: 2, name: "control", date: "1.1.2020" },
+  ]);
+  //second mock table
+  const [rows_B, setRows_B] = useState<FirmwareTableRow[]>([
+    { id: 0, name: "calculator", date: "14.12.2020" },
+    { id: 1, name: "donner", date: "11.1.2019" },
+    { id: 2, name: "creation", date: "1.1.2019" },
+    { id: 3, name: "Grrrreetings!", date: "1.12.2018" },
+    { id: 4, name: "randomNumber", date: "21.11.2019" },
   ]);
   
   useEffect(() => {
@@ -39,7 +49,7 @@ export default function Home() {
         user_storage_name: storageName,
       });
       sessionStorage.removeItem("storageToDelete"); // Clean up
-    }
+    }      
   }, []);
 
   const [isEditDisabled, setIsEditDisabled] = useState(true);
@@ -56,7 +66,7 @@ export default function Home() {
             <HorizontalLinearStepper activeStep={activeStep} />
           </Box>
           <Box sx={{ mt: 4 }}>
-            <FirmwareTable rows={rows} onEditDisabledChange={handleEditDisabledChange} />
+            <FirmwareTable rows={(sessionStorage.getItem("selectedStorage") === "quick-flash")? rows : rows_B} onEditDisabledChange={handleEditDisabledChange} />
           </Box>
           {
             /* <Button

--- a/src/app/flash/storage/page.tsx
+++ b/src/app/flash/storage/page.tsx
@@ -88,6 +88,7 @@ export default function Home() {
     const curr_id = selectedStorage.row.id;
     toggleRowVisibility(curr_id);
     sessionStorage.removeItem("storageToDelete"); // Clean up
+    setIsEditDisabled(false);
     console.log("Undo action triggered.");
   };
 
@@ -100,6 +101,7 @@ export default function Home() {
     // Toggle visibility using the latest selected_storage
     toggleRowVisibility(selectedStorage.row.id);
     sessionStorage.setItem("storageToDelete", selectedStorage.row.name);
+    setIsEditDisabled(true);
     // Show toast notification with undo action
     toastManagerRef.current?.showToast({
       type: "warning",
@@ -114,6 +116,7 @@ export default function Home() {
         invoke<StorageCredentials[]>("remove_storage_credentials", {
           user_storage_name: selectedStorage.row.name,
         });
+        setSelectedStorage(null);
       },
     });
   }; 
@@ -121,7 +124,7 @@ export default function Home() {
   const handleEditAction = () => {};
 
 
-  useEffect(() => {
+ /* useEffect(() => {
     const handleBeforeUnload = () => {
       console.log("Page is about to be refreshed or closed");
       // Perform any necessary cleanup or save data here
@@ -132,7 +135,7 @@ export default function Home() {
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, []);
+  }, []);*/
 
   return (
     <main>
@@ -145,6 +148,7 @@ export default function Home() {
             <StorageTable
               rows={filteredRows}
               onEditDisabledChange={handleEditDisabledChange}
+              isEditDisabled={isEditDisabled}
               handleClose={() => {}}
               open={false}
               handleEdit={handleEditAction}

--- a/src/app/flash/storage/page.tsx
+++ b/src/app/flash/storage/page.tsx
@@ -59,7 +59,10 @@ export default function Home() {
     setSelectedStorage(newRow);
     setIsEditDisabled(newState);
     if(selectedStorage)
+    {
       console.log(selectedStorage.row.name);
+      sessionStorage.setItem("selectedStorage", selectedStorage.row.name);
+    }
   };
 
   const handleStart = () => {

--- a/src/app/flash/storage/page.tsx
+++ b/src/app/flash/storage/page.tsx
@@ -9,6 +9,7 @@ import { StorageTableRow } from "@/components/StorageTable";
 import HorizontalLinearStepper from "@/components/Stepper";
 import Link from "next/link";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
+import ToastManager from "@/components/ToastManager";
 
 import { invoke } from "@tauri-apps/api/core";
 
@@ -60,6 +61,30 @@ export default function Home() {
     });
   };
 
+  const toastManagerRef = React.useRef<{ showToast: Function }>(null);
+
+  const handleUndoAction = () => {
+    //TODO: Revert the change associated with the toast
+    console.log("Undo action triggered.")
+  };
+
+  const handleDeleteAction = () => {
+    //TODO: handle delete logic here
+
+    toastManagerRef.current?.showToast({
+      type: "warning",
+      message: "Deleted a storage!",
+      duration: 7000,
+      action: {
+        label: "Undo",
+        onClick: () => handleUndoAction,
+      },
+    });
+  }
+  const handleEditAction = () => {
+
+  }
+
   return (
     <main>
       <Container maxWidth="xl">
@@ -68,7 +93,13 @@ export default function Home() {
             <HorizontalLinearStepper activeStep={activeStep} />
           </Box>
           <Box sx={{ mt: 4 }}>
-            <StorageTable rows={rows} onEditDisabledChange={handleEditDisabledChange} />
+            <StorageTable
+             rows={rows}
+             onEditDisabledChange={handleEditDisabledChange}
+             handleClose={() => {}} 
+             open={false}
+             handleEdit={handleEditAction}
+             handleDelete={handleDeleteAction}/>
           </Box>
           {
             /* <Button
@@ -98,6 +129,7 @@ export default function Home() {
           }
           <Box></Box>
         </Box>
+        <ToastManager ref={toastManagerRef} />
       </Container>
     </main>
   );

--- a/src/app/flash/storage/page.tsx
+++ b/src/app/flash/storage/page.tsx
@@ -79,6 +79,9 @@ export default function Home() {
         label: "Undo",
         onClick: () => handleUndoAction,
       },
+      onAutoClose: () => {
+        console.log('Toast duration ended! Performing auto-close action...');
+      },
     });
   }
   const handleEditAction = () => {

--- a/src/app/flash/storage/page.tsx
+++ b/src/app/flash/storage/page.tsx
@@ -3,7 +3,7 @@
 import { Box, Button, Container } from "@mui/material";
 import * as React from "react";
 import Typography from "@mui/material/Typography";
-import { useState, useCallback } from "react";
+import { useState, useEffect } from "react";
 import StorageTable from "@/components/StorageTable";
 import { StorageTableRow } from "@/components/StorageTable";
 import HorizontalLinearStepper from "@/components/Stepper";
@@ -87,6 +87,7 @@ export default function Home() {
     }
     const curr_id = selectedStorage.row.id;
     toggleRowVisibility(curr_id);
+    sessionStorage.removeItem("storageToDelete"); // Clean up
     console.log("Undo action triggered.");
   };
 
@@ -98,11 +99,11 @@ export default function Home() {
   
     // Toggle visibility using the latest selected_storage
     toggleRowVisibility(selectedStorage.row.id);
-  
+    sessionStorage.setItem("storageToDelete", selectedStorage.row.name);
     // Show toast notification with undo action
     toastManagerRef.current?.showToast({
       type: "warning",
-      message: `Deleted a storage! - ${selectedStorage.row.name}`,
+      message: `Deleted ${selectedStorage.row.name}!`,
       duration: 7000,
       action: {
         label: "Undo",
@@ -118,6 +119,20 @@ export default function Home() {
   }; 
 
   const handleEditAction = () => {};
+
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      console.log("Page is about to be refreshed or closed");
+      // Perform any necessary cleanup or save data here
+    };
+  
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
 
   return (
     <main>

--- a/src/app/flash/version/page.tsx
+++ b/src/app/flash/version/page.tsx
@@ -3,7 +3,7 @@
 import { Box, Button, Container } from "@mui/material";
 import * as React from "react";
 import Typography from "@mui/material/Typography";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import VersionTable from "@/components/VersionTable";
 import { VersionTableRow } from "@/components/VersionTable";
 import HorizontalLinearStepper from "@/components/Stepper";
@@ -16,12 +16,20 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 export default function Home() {
   const [activeStep, setActiveStep] = React.useState(2);
   const [rows, setRows] = useState<VersionTableRow[]>([
-    { id: 0, name: "68b468c846 ", date: "19.9.2021", chipName: "fintel" },
+    { id: 0, name: "26 ", date: "19.9.2021", chipName: "fintel" },
     { id: 1, name: "24", date: "19.9.2021", chipName: "fintel" },
     { id: 2, name: "21", date: "18.6.2021", chipName: "fintel" },
     { id: 3, name: "20", date: "17.6.2021", chipName: "fintel" },
     { id: 4, name: "18", date: "15.6.2021", chipName: "fintel" },
   ]);
+  //second mock table
+
+  const [rows_B, setRows_B] = useState<VersionTableRow[]>([
+    { id: 0, name: "6ef8 ", date: "13.10.2020", chipName: "raspberry" },
+    { id: 1, name: "2b1a", date: "19.6.2020", chipName: "raspberry" },
+    { id: 2, name: "ff68", date: "17.6.2020", chipName: "raspberry" },
+  ]);
+
 
   const [isEditDisabled, setIsEditDisabled] = useState(true);
 
@@ -37,7 +45,7 @@ export default function Home() {
             <HorizontalLinearStepper activeStep={activeStep} />
           </Box>
           <Box sx={{ mt: 4 }}>
-            <VersionTable rows={rows} onEditDisabledChange={handleEditDisabledChange} />
+            <VersionTable rows={(sessionStorage.getItem("selectedStorage") === "quick-flash")? rows : rows_B} onEditDisabledChange={handleEditDisabledChange} />
           </Box>
           {
             /* <Button

--- a/src/app/flash/version/page.tsx
+++ b/src/app/flash/version/page.tsx
@@ -23,7 +23,6 @@ export default function Home() {
     { id: 4, name: "18", date: "15.6.2021", chipName: "fintel" },
   ]);
   //second mock table
-
   const [rows_B, setRows_B] = useState<VersionTableRow[]>([
     { id: 0, name: "6ef8 ", date: "13.10.2020", chipName: "raspberry" },
     { id: 1, name: "2b1a", date: "19.6.2020", chipName: "raspberry" },

--- a/src/components/StorageTable.tsx
+++ b/src/components/StorageTable.tsx
@@ -152,7 +152,7 @@ export default function StorageTable(
     handleDelete
   }: {
     rows: StorageTableRow[];
-    onEditDisabledChange: (value: boolean) => void;
+    onEditDisabledChange: (value: boolean, params: GridRowParams) => void;
   } & ObtainingXMLDialogProps,
 ) {
 
@@ -167,7 +167,8 @@ export default function StorageTable(
 
   const handleRowClick: GridEventListener<"rowClick"> = (params: GridRowParams) => {
     setIsEditDisabled(false); // Enable the Edit button on row click
-    onEditDisabledChange(false);
+    onEditDisabledChange(false, params);
+
   };
 
   return (

--- a/src/components/StorageTable.tsx
+++ b/src/components/StorageTable.tsx
@@ -76,8 +76,17 @@ const columns: GridColDef<StorageTableRow>[] = [
   { field: 'connectionStatus', headerName: 'Connection status', flex: 1 },
 ];*/
 
-function EditToolbar({ isEditDisabled }: { isEditDisabled: boolean }) {
-  const apiRef = useGridApiContext();
+export interface ObtainingXMLDialogProps {
+  isEditDisabled?: boolean;
+  handleClose: () => void;
+  open: boolean;
+  handleEdit: () => void;
+  handleDelete: () => void;
+}
+
+function EditToolbar(props: ObtainingXMLDialogProps) {
+  //const apiRef = useGridApiContext();
+  const { isEditDisabled, handleClose, open, handleEdit, handleDelete, ...other } = props;
 
   const [openEditDialog, setOpenEditDialog] = useState(false);
   const [openAddDialog, setOpenAddDialog] = useState(false);
@@ -117,7 +126,7 @@ function EditToolbar({ isEditDisabled }: { isEditDisabled: boolean }) {
         handleClose={() => setOpenEditDialog(false)}
         open={openEditDialog}
         handleEdit={() => {}}
-        handleDelete={() => {}}
+        handleDelete={handleDelete}
       />
       <AddStorageDialog
         handleClose={() => setOpenAddDialog(false)}
@@ -127,19 +136,26 @@ function EditToolbar({ isEditDisabled }: { isEditDisabled: boolean }) {
       <DeleteConfirmation
         handleClose={() => setOpenRemoveDialog(false)}
         open={openRemoveDialog}
-        handleConfirm={() => {}}
+        handleConfirm={handleDelete}
       />
     </>
   );
 }
 
-export default function StorageTable({
-  rows,
-  onEditDisabledChange,
-}: {
-  rows: StorageTableRow[];
-  onEditDisabledChange: (value: boolean) => void;
-}) {
+export default function StorageTable(
+  {
+    rows,
+    onEditDisabledChange,
+    handleClose,
+    open,
+    handleEdit,
+    handleDelete
+  }: {
+    rows: StorageTableRow[];
+    onEditDisabledChange: (value: boolean) => void;
+  } & ObtainingXMLDialogProps,
+) {
+
   const router = useRouter();
   const handleRowDoubleClick: GridEventListener<"rowDoubleClick"> = (params: GridRowParams) => {
     // Handles the double click event
@@ -158,7 +174,13 @@ export default function StorageTable({
     <Box sx={{ width: "100%" }}>
       <DataGrid
         slots={{
-          toolbar: () => <EditToolbar isEditDisabled={isEditDisabled} />,
+          toolbar: () => 
+          <EditToolbar 
+          isEditDisabled={isEditDisabled}
+          handleClose={handleClose}
+          open={open}
+          handleEdit={handleEdit}
+          handleDelete={handleDelete} />,
         }}
         rows={rows}
         columns={columns}

--- a/src/components/StorageTable.tsx
+++ b/src/components/StorageTable.tsx
@@ -77,7 +77,7 @@ const columns: GridColDef<StorageTableRow>[] = [
 ];*/
 
 export interface ObtainingXMLDialogProps {
-  isEditDisabled?: boolean;
+  isEditDisabled: boolean;
   handleClose: () => void;
   open: boolean;
   handleEdit: () => void;
@@ -145,6 +145,7 @@ function EditToolbar(props: ObtainingXMLDialogProps) {
 export default function StorageTable({
   rows,
   onEditDisabledChange,
+  isEditDisabled,
   handleClose,
   open,
   handleEdit,
@@ -161,11 +162,11 @@ export default function StorageTable({
     router.push("/flash/firmware");
   };
 
-  const [isEditDisabled, setIsEditDisabled] = useState(true);
+  //const [isEditDisabled, setIsEditDisabled] = useState(true);
 
   const handleRowClick: GridEventListener<"rowClick"> = (params: GridRowParams) => {
     onEditDisabledChange(false, params);
-    setIsEditDisabled(false); // Enable the Edit button on row click
+    //setIsEditDisabled(false); // Enable the Edit button on row click
   };
 
   return (

--- a/src/components/StorageTable.tsx
+++ b/src/components/StorageTable.tsx
@@ -142,21 +142,19 @@ function EditToolbar(props: ObtainingXMLDialogProps) {
   );
 }
 
-export default function StorageTable(
-  {
-    rows,
-    onEditDisabledChange,
-    handleClose,
-    open,
-    handleEdit,
-    handleDelete
-  }: {
-    rows: StorageTableRow[];
-    onEditDisabledChange: (value: boolean, params: GridRowParams) => void;
-  } & ObtainingXMLDialogProps,
-) {
-
+export default function StorageTable({
+  rows,
+  onEditDisabledChange,
+  handleClose,
+  open,
+  handleEdit,
+  handleDelete,
+}: {
+  rows: StorageTableRow[];
+  onEditDisabledChange: (value: boolean, params: GridRowParams) => void;
+} & ObtainingXMLDialogProps) {
   const router = useRouter();
+  
   const handleRowDoubleClick: GridEventListener<"rowDoubleClick"> = (params: GridRowParams) => {
     // Handles the double click event
     console.log("Row double-clicked:", params.row);
@@ -166,22 +164,23 @@ export default function StorageTable(
   const [isEditDisabled, setIsEditDisabled] = useState(true);
 
   const handleRowClick: GridEventListener<"rowClick"> = (params: GridRowParams) => {
-    setIsEditDisabled(false); // Enable the Edit button on row click
     onEditDisabledChange(false, params);
-
+    setIsEditDisabled(false); // Enable the Edit button on row click
   };
 
   return (
     <Box sx={{ width: "100%" }}>
       <DataGrid
         slots={{
-          toolbar: () => 
-          <EditToolbar 
-          isEditDisabled={isEditDisabled}
-          handleClose={handleClose}
-          open={open}
-          handleEdit={handleEdit}
-          handleDelete={handleDelete} />,
+          toolbar: () => (
+            <EditToolbar
+              isEditDisabled={isEditDisabled}
+              handleClose={handleClose}
+              open={open}
+              handleEdit={handleEdit}
+              handleDelete={handleDelete}
+            />
+          ),
         }}
         rows={rows}
         columns={columns}

--- a/src/components/ToastManager.tsx
+++ b/src/components/ToastManager.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef, useImperativeHandle } from 'react';
-import { toast, ToastContainer, ToastContent, ToastOptions } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import React, { forwardRef, useImperativeHandle } from "react";
+import { toast, ToastContainer, ToastContent, ToastOptions } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
-type ToastType = 'success' | 'info' | 'error' | 'warning';
+type ToastType = "success" | "info" | "error" | "warning";
 
 interface ToastAction {
   label: string;
@@ -14,21 +14,30 @@ interface ShowToastProps {
   message: string;
   duration?: number;
   action?: ToastAction;
+  onAutoClose?: () => void; // New optional callback
 }
 
 const ToastManager = forwardRef((props, ref) => {
   // Expose the showToast function via ref
   useImperativeHandle(ref, () => ({
-    showToast: ({ type, message, duration = 5000, action }: ShowToastProps) => {
+    showToast: ({ type, message, duration = 5000, action, onAutoClose }: ShowToastProps) => {
+      let manuallyClosed = false; // Flag to track manual closure
+
       const toastOptions: ToastOptions = {
         type,
         autoClose: duration,
         hideProgressBar: false,
-        position: 'bottom-center',
+        position: "bottom-center",
         closeOnClick: true,
         pauseOnHover: true,
         draggable: false,
         progress: undefined,
+        onClose: (props) => {
+          // Check if the toast was auto-closed (not dismissed manually)
+          if (!manuallyClosed && onAutoClose) {
+            onAutoClose();
+          }
+        },
       };
 
       if (action) {
@@ -38,23 +47,28 @@ const ToastManager = forwardRef((props, ref) => {
               {message}
               <button
                 onClick={() => {
+                  /*
+                  we are clicking on a button, that likely Undoes
+                  Therefore, we ARE closing the toast, but we do not want to trigger the
+                  */
+                  manuallyClosed = true;
                   action.onClick();
                   closeToast();
                 }}
                 style={{
-                  marginLeft: '10px',
-                  padding: '5px 10px',
-                  backgroundColor: '#f0f0f0',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
+                  marginLeft: "10px",
+                  padding: "5px 10px",
+                  backgroundColor: "#f0f0f0",
+                  border: "none",
+                  borderRadius: "4px",
+                  cursor: "pointer",
                 }}
               >
                 {action.label}
               </button>
             </div>
           ),
-          toastOptions
+          toastOptions,
         );
       } else {
         toast(message, toastOptions);

--- a/src/components/ToastManager.tsx
+++ b/src/components/ToastManager.tsx
@@ -1,0 +1,68 @@
+import React, { forwardRef, useImperativeHandle } from 'react';
+import { toast, ToastContainer, ToastContent, ToastOptions } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+type ToastType = 'success' | 'info' | 'error' | 'warning';
+
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+interface ShowToastProps {
+  type: ToastType;
+  message: string;
+  duration?: number;
+  action?: ToastAction;
+}
+
+const ToastManager = forwardRef((props, ref) => {
+  // Expose the showToast function via ref
+  useImperativeHandle(ref, () => ({
+    showToast: ({ type, message, duration = 5000, action }: ShowToastProps) => {
+      const toastOptions: ToastOptions = {
+        type,
+        autoClose: duration,
+        hideProgressBar: false,
+        position: 'bottom-center',
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: false,
+        progress: undefined,
+      };
+
+      if (action) {
+        toast(
+          ({ closeToast }) => (
+            <div>
+              {message}
+              <button
+                onClick={() => {
+                  action.onClick();
+                  closeToast();
+                }}
+                style={{
+                  marginLeft: '10px',
+                  padding: '5px 10px',
+                  backgroundColor: '#f0f0f0',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                }}
+              >
+                {action.label}
+              </button>
+            </div>
+          ),
+          toastOptions
+        );
+      } else {
+        toast(message, toastOptions);
+      }
+    },
+  }));
+
+  return <ToastContainer />;
+});
+
+export default ToastManager;

--- a/src/components/ToastManager.tsx
+++ b/src/components/ToastManager.tsx
@@ -28,7 +28,7 @@ const ToastManager = forwardRef((props, ref) => {
         autoClose: duration,
         hideProgressBar: false,
         position: "bottom-center",
-        closeOnClick: true,
+        closeOnClick: false,
         pauseOnHover: true,
         draggable: false,
         progress: undefined,


### PR DESCRIPTION
Snackbar gets unmounted after the user changes pages/reloads - relevant when clicking on continue right after deleting a storage.
Current handling of this is remember the storage which has been marked for deletion, and deleting it on the firmware page.